### PR TITLE
Fixed "其他语言"/"other languages" Section

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -1,3 +1,5 @@
+[简体中文](README.md) | [日本語](README-ja.md) | [沖縄](README-ryu.md)
+
 <p align="center">
 <img width="300" src="./assets/icon/logo.png" alt="Miru 看板娘"/>
 </p>

--- a/README-en.md
+++ b/README-en.md
@@ -4,11 +4,6 @@
 <img width="300" src="./assets/icon/logo.png" alt="Miru 看板娘"/>
 </p>
 
-## Other language
-- [Simplified Chinese](README.md)
-- [Japanese](README-ja.md)
-- [Okinawan](README-ryu.md)
-
 <h1 align="center">
 Miru App
 </h1>

--- a/README-en.md
+++ b/README-en.md
@@ -1,4 +1,4 @@
-[简体中文](README.md) | [日本語](README-ja.md) | [沖縄](README-ryu.md)
+[简体中文](README.md) | [日本語](README-ja.md) | [うちなーぐち](README-ryu.md)
 
 <p align="center">
 <img width="300" src="./assets/icon/logo.png" alt="Miru 看板娘"/>

--- a/README-ja.md
+++ b/README-ja.md
@@ -1,4 +1,4 @@
-[簡体字中国語](README.md) | [English](README-en.md) | [うちなーぐち](README-ryu.md)
+[简体中文](README.md) | [English](README-en.md) | [うちなーぐち](README-ryu.md)
 
 <p align="center">
 <img width="300" src="./assets/icon/logo.png" alt="Miru 看板娘"/>

--- a/README-ja.md
+++ b/README-ja.md
@@ -1,11 +1,8 @@
+[簡体字中国語](README.md) | [English](README-en.md) | [うちなーぐち](README-ryu.md)
+
 <p align="center">
 <img width="300" src="./assets/icon/logo.png" alt="Miru 看板娘"/>
 </p>
-
-## その他の言語
-- [簡体字中国語](README.md)
-- [英語](README-en.md)
-- [うちなーぐち](README-ryu.md)
 
 <h1 align="center">
 Miru App

--- a/README-ryu.md
+++ b/README-ryu.md
@@ -1,11 +1,8 @@
+- [简体中文](README.md) | [English](README-en.md) | [日本語](README-ja.md)
+
 <p align="center">
 <img width="300" src="./assets/icon/logo.png" alt="Miru 看板娘"/>
 </p>
-
-## うぬふかぬぎんぐ
-- [かなーちゃるいじちゅうぐくぐ](README.md)
-- [えいぐ](README-en.md)
-- [んかいふらぐ](README-ja.md)
 
 <h1 align="center">
 Miru App

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
+[English](README-en.md) | [日本語](README-ja.md) | [沖縄](README-ryu.md)
+
+
 <p align="center">
 <img width="300" src="./assets/icon/logo.png" alt="Miru 看板娘"/>
 </p>
-
-## 其他语言
-- [英语](README-en.md)
-- [日语](README-ja.md)
-- [沖繩語](README-ryu.md)
 
 <h1 align="center">
 Miru App

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[English](README-en.md) | [日本語](README-ja.md) | [沖縄](README-ryu.md)
+[English](README-en.md) | [日本語](README-ja.md) | [うちなーぐち](README-ryu.md)
 
 
 <p align="center">


### PR DESCRIPTION
Moved and Changed Language name to there Language (like: "英语 -> English" on README.md)
Why?
Lets there is English speaking user came on repo and whats to view English version of README but that user won't able to find it as you have written on "Simplified Chinese" or other language on other README

and as for "其他语言"/"other languages" title I removed it because if word language's are written in there respective language then title became useless and if title isn't there it looks ugly so moved on top 