### PR TITLE
CI: Upload different installation packages separately

### DIFF
--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Upload Artifact - x86
         uses: actions/upload-artifact@v3
         with:
-          path: "build/app/outputs/flutter-apk/app-x86-release.apk"
-          name: Miru-pr-${{ github.event.pull_request.number }-x86.apk
+          path: "build/app/outputs/flutter-apk/app-x86_64-release.apk"
+          name: Miru-pr-${{ github.event.pull_request.number }-x86_64.apk
 
   build-and-release-windows:
     runs-on: windows-latest

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -39,10 +39,21 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD}}
 
       # 发布安装包
-      - name: Upload Artifact
+      - name: Upload Artifact - armeabi-v7a
         uses: actions/upload-artifact@v3
         with:
-          path: "build/app/outputs/flutter-apk/app-*.apk"
+          path: "build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk"
+          name: Miru-${{github.ref_name}}-armeabi-v7a.apk
+      - name: Upload Artifact - arm64-v8a
+        uses: actions/upload-artifact@v3
+        with:
+          path: "build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
+          name: Miru-${{github.ref_name}}-arm64-v8a.apk
+      - name: Upload Artifact - x86
+        uses: actions/upload-artifact@v3
+        with:
+          path: "build/app/outputs/flutter-apk/app-x86-release.apk"
+          name: Miru-${{github.ref_name}}-x86.apk
 
   build-and-release-windows:
     runs-on: windows-latest
@@ -68,3 +79,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: "build/windows/runner/Release/Miru-${{github.ref_name}}-windows.zip"
+          name: Miru-${{github.ref_name}}-windows.zip

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -43,17 +43,17 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: "build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk"
-          name: Miru-${{github.ref_name}}-armeabi-v7a.apk
+          name: Miru-pr-${{ github.event.pull_request.number }-armeabi-v7a.apk
       - name: Upload Artifact - arm64-v8a
         uses: actions/upload-artifact@v3
         with:
           path: "build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
-          name: Miru-${{github.ref_name}}-arm64-v8a.apk
+          name: Miru-pr-${{ github.event.pull_request.number }-arm64-v8a.apk
       - name: Upload Artifact - x86
         uses: actions/upload-artifact@v3
         with:
           path: "build/app/outputs/flutter-apk/app-x86-release.apk"
-          name: Miru-${{github.ref_name}}-x86.apk
+          name: Miru-pr-${{ github.event.pull_request.number }-x86.apk
 
   build-and-release-windows:
     runs-on: windows-latest
@@ -72,11 +72,11 @@ jobs:
         uses: thedoctor0/zip-release@master
         with:
           type: "zip"
-          filename: Miru-${{github.ref_name}}-windows.zip
+          filename: Miru-pr-${{ github.event.pull_request.number }}-windows.zip
           directory: build/windows/runner/Release
       # 发布安装包
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          path: "build/windows/runner/Release/Miru-${{github.ref_name}}-windows.zip"
-          name: Miru-${{github.ref_name}}-windows.zip
+          path: "build/windows/runner/Release/Miru-pr-${{ github.event.pull_request.number }}-windows.zip"
+          name: Miru-pr-${{ github.event.pull_request.number }}-windows.zip

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -43,17 +43,17 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: "build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk"
-          name: Miru-pr-${{ github.event.pull_request.number }-armeabi-v7a.apk
+          name: Miru-pr-${{ github.event.pull_request.number }}-armeabi-v7a.apk
       - name: Upload Artifact - arm64-v8a
         uses: actions/upload-artifact@v3
         with:
           path: "build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
-          name: Miru-pr-${{ github.event.pull_request.number }-arm64-v8a.apk
+          name: Miru-pr-${{ github.event.pull_request.number }}-arm64-v8a.apk
       - name: Upload Artifact - x86
         uses: actions/upload-artifact@v3
         with:
           path: "build/app/outputs/flutter-apk/app-x86_64-release.apk"
-          name: Miru-pr-${{ github.event.pull_request.number }-x86_64.apk
+          name: Miru-pr-${{ github.event.pull_request.number }}-x86_64.apk
 
   build-and-release-windows:
     runs-on: windows-latest


### PR DESCRIPTION
## BREAKING CHANGE

The names of the uploaded build artifacts will change:

**Origin**:

- `artifacts.zip`

**Now**:

- `Miru-pr-${{ github.event.pull_request.number }}-windows.zip`
- `Miru-pr-${{ github.event.pull_request.number }-<ARCH>.apk`

> The file name will not change after the decompression.

## Description

Upload different installation packages separately to reduce the size of individual artifacts.

## Why?

It can be seen that the original CI build upload package is all packed into a folder and then uploaded.

However, if you only want to **download a certain version of the installation package**, this workflow obviously does **not support**. And the last uploaded package size is also relatively large.

## Additional Content

等这个 CI 能不能过再说（笑

由于上传 action 的特殊性，没有办法直接用 path 里指示 `app-*.apk` 来把里面的安装包逐个逐个上传上去，这样做也还是会把 3 个 apk 变成一个压缩包。很明显不符合预期。

参考 https://docs.flutter.dev/deployment/android#build-an-apk 能发现只会有三种 apk：

- `[project]/build/app/outputs/apk/release/app-armeabi-v7a-release.apk`
- `[project]/build/app/outputs/apk/release/app-arm64-v8a-release.apk`
- `[project]/build/app/outputs/apk/release/app-x86_64-release.apk`

反正也不多，直接在 workflow file 里全手动写上传就好。至于未来还会不会出现其他的就再说吧（我觉得）而且也不太可能