### PR TITLE
CI: Add `dev` to build branch

### DIFF
--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -1,10 +1,12 @@
 # This is a basic workflow to help you get started with Actions
 
-name: prbuild
+name: Dev Build CI
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
+  push:
+    branches: ["dev"]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 # This is a basic workflow to help you get started with Actions
 
-name: build
+name: Release CI
 
-# git push --tags 执行时候进行编译
 on:
   push:
     tags:
@@ -17,6 +16,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: main
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -33,6 +33,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+        with:
+          ref: main
       - name: Flutter action
         uses: subosito/flutter-action@v2
         with:
@@ -70,6 +72,8 @@ jobs:
 
   #   steps:
   #     - uses: actions/checkout@v3
+  #       with:
+  #         ref: main
   #     - uses: subosito/flutter-action@v2
   #       with:
   #         flutter-version: 3.10.3
@@ -106,6 +110,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: main
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: 3.13.0


### PR DESCRIPTION
## BREAKING CHANGES

- In `release.yml`, all checkout step uses `ref: main`, to confirm that ci is using code on main.
- `build` CI is renamed to **`Release CI`**
- `prbuild` CI is renamed to **`Dev Build CI`**
- Both **PR and `push` event** on the **`dev`** branch will trigger **`Dev Build CI`**