### PR TITLE
Add lang information on extension manager page

### DIFF
--- a/lib/views/pages/extension/extension_repo_page.dart
+++ b/lib/views/pages/extension/extension_repo_page.dart
@@ -62,6 +62,7 @@ class _ExtensionRepoPageState extends State<ExtensionRepoPage> {
             icon: e['icon'],
             version: e['version'],
             package: e['package'],
+            lang: e['lang'],
             nsfw: e['nsfw'] == 'true',
             type: ExtensionType.values.firstWhere(
               (element) => element.toString() == 'ExtensionType.${e['type']}',

--- a/lib/views/widgets/extension/extension_card.dart
+++ b/lib/views/widgets/extension/extension_card.dart
@@ -15,6 +15,7 @@ class ExtensionCard extends StatefulWidget {
     required this.version,
     required this.icon,
     required this.package,
+    required this.lang,
     required this.nsfw,
     required this.type,
   });
@@ -22,6 +23,7 @@ class ExtensionCard extends StatefulWidget {
   final String name;
   final String version;
   final String package;
+  final String lang;
   final ExtensionType type;
   final bool nsfw;
 
@@ -86,6 +88,13 @@ class _ExtensionCardState extends State<ExtensionCard> {
             padding: const EdgeInsets.only(right: 8),
             child: Text(
               widget.version,
+              style: const TextStyle(fontSize: 12),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Text(
+              widget.lang,
               style: const TextStyle(fontSize: 12),
             ),
           ),
@@ -178,6 +187,13 @@ class _ExtensionCardState extends State<ExtensionCard> {
                 padding: const EdgeInsets.only(right: 8),
                 child: Text(
                   ExtensionUtils.typeToString(widget.type),
+                  style: const TextStyle(fontSize: 12),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Text(
+                  widget.lang,
                   style: const TextStyle(fontSize: 12),
                 ),
               ),

--- a/lib/views/widgets/extension/extension_card.dart
+++ b/lib/views/widgets/extension/extension_card.dart
@@ -94,14 +94,14 @@ class _ExtensionCardState extends State<ExtensionCard> {
           Padding(
             padding: const EdgeInsets.only(right: 8),
             child: Text(
-              widget.lang,
+              ExtensionUtils.typeToString(widget.type),
               style: const TextStyle(fontSize: 12),
             ),
           ),
           Padding(
             padding: const EdgeInsets.only(right: 8),
             child: Text(
-              ExtensionUtils.typeToString(widget.type),
+              widget.lang,
               style: const TextStyle(fontSize: 12),
             ),
           ),

--- a/lib/views/widgets/extension/extension_card.dart
+++ b/lib/views/widgets/extension/extension_card.dart
@@ -82,42 +82,34 @@ class _ExtensionCardState extends State<ExtensionCard> {
         ),
       ),
       title: Text(widget.name),
-      subtitle: Row(
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: Text(
-              widget.version,
-              style: const TextStyle(fontSize: 12),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: Text(
-              ExtensionUtils.typeToString(widget.type),
-              style: const TextStyle(fontSize: 12),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: Text(
-              widget.lang,
-              style: const TextStyle(fontSize: 12),
-            ),
-          ),
-          if (widget.nsfw)
-            const Padding(
-              padding: EdgeInsets.only(right: 8),
-              child: Text(
-                '18+',
-                style: TextStyle(
-                  color: Colors.redAccent,
-                  fontSize: 12,
-                ),
+      subtitle: DefaultTextStyle(
+          style: const TextStyle(fontSize: 12),
+          child: Row(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Text(widget.version),
               ),
-            ),
-        ],
-      ),
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Text(ExtensionUtils.typeToString(widget.type)),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Text(widget.lang),
+              ),
+              if (widget.nsfw)
+                const Padding(
+                  padding: EdgeInsets.only(right: 8),
+                  child: Text(
+                    '18+',
+                    style: TextStyle(
+                      color: Colors.redAccent,
+                    ),
+                  ),
+                ),
+            ],
+          )),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -181,34 +173,30 @@ class _ExtensionCardState extends State<ExtensionCard> {
           ),
           const SizedBox(height: 8),
           Text(widget.name, style: const TextStyle(fontSize: 17)),
-          Row(
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(right: 8),
-                child: Text(
-                  ExtensionUtils.typeToString(widget.type),
-                  style: const TextStyle(fontSize: 12),
+          DefaultTextStyle(
+            style: const TextStyle(fontSize: 12),
+            child: Row(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: Text(ExtensionUtils.typeToString(widget.type)),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(right: 8),
-                child: Text(
-                  widget.lang,
-                  style: const TextStyle(fontSize: 12),
+                Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: Text(widget.lang),
                 ),
-              ),
-              if (widget.nsfw)
-                const Padding(
-                  padding: EdgeInsets.only(right: 8),
-                  child: Text(
-                    '18+',
-                    style: TextStyle(
-                      color: Colors.redAccent,
-                      fontSize: 12,
+                if (widget.nsfw)
+                  const Padding(
+                    padding: EdgeInsets.only(right: 8),
+                    child: Text(
+                      '18+',
+                      style: TextStyle(
+                        color: Colors.redAccent,
+                      ),
                     ),
                   ),
-                ),
-            ],
+              ],
+            ),
           ),
           Row(
             children: [


### PR DESCRIPTION
I don't know many sources in the extension manager, and have to install it to check its language.
This commit adds the source language next to extension type, letting the user to know before installing it.

I don't know flutter very well, so, fell free to suggest improvements.